### PR TITLE
Fix UnsynchTextFrame byte format

### DIFF
--- a/encodedbytes/reader.go
+++ b/encodedbytes/reader.go
@@ -71,12 +71,13 @@ func (r *Reader) ReadRestString(encoding byte) (string, error) {
 
 // Read a null terminated string of specified encoding
 func (r *Reader) ReadNullTermString(encoding byte) (string, error) {
-	b, err := r.ReadNumBytes(afterNullIndex(r.data[r.index:], encoding))
+	atIndex, afterIndex := nullIndex(r.data[r.index:], encoding)
+	b, err := r.ReadNumBytes(afterIndex)
 	if err != nil {
 		return "", err
 	}
 
-	return Decoders[encoding].ConvertString(string(b))
+	return Decoders[encoding].ConvertString(string(b[:atIndex]))
 }
 
 func NewReader(b []byte) *Reader { return &Reader{b, 0} }

--- a/encodedbytes/writer.go
+++ b/encodedbytes/writer.go
@@ -48,4 +48,12 @@ func (w *Writer) WriteString(s string, encoding byte) (err error) {
 	return
 }
 
+func (w *Writer) WriteNullTermString(s string, encoding byte) (err error) {
+	err = w.WriteString(s, encoding)
+	if err == nil {
+		err = w.WriteByte(0)
+	}
+	return
+}
+
 func NewWriter(b []byte) *Writer { return &Writer{b, 0} }

--- a/v2/frame_test.go
+++ b/v2/frame_test.go
@@ -1,0 +1,29 @@
+package v2
+
+import (
+	"testing"
+)
+
+func TestUnsynchTextFrame_SetEncoding(t *testing.T) {
+	f := NewUnsychTextFrame(V23CommonFrame["Comments"], "Foo", "Bar")
+	size := f.Size()
+
+	err := f.SetEncoding("UTF-16")
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSize := f.Size()
+	if newSize-size != 1 {
+		t.Errorf("expected size to increase to %d, but it was %d", size+1, newSize)
+	}
+
+	size = newSize
+	err := f.SetEncoding("UTF-16")
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSize := f.Size()
+	if newSize-size != -1 {
+		t.Errorf("expected size to decrease to %d, but it was %d", size-1, newSize)
+	}
+}


### PR DESCRIPTION
- change encodedBytes.Reader's ReadNullTermString behavior to strip off
  null byte(s)
- add WriteNullTermString function to encodedBytes.Writer
- include NullLength information in encodingbytes.EncodingMap
- increase size of UnsynchTextFrame by the null length of the encoding
- automatically null-terminate description string in
  UnsynchTextFrame.Bytes()
