### PR TITLE
prevent panicking when reading malformed COMM tags

### DIFF
--- a/encodedbytes/reader.go
+++ b/encodedbytes/reader.go
@@ -4,6 +4,7 @@
 package encodedbytes
 
 import (
+	"errors"
 	"io"
 )
 
@@ -72,6 +73,10 @@ func (r *Reader) ReadRestString(encoding byte) (string, error) {
 // Read a null terminated string of specified encoding
 func (r *Reader) ReadNullTermString(encoding byte) (string, error) {
 	atIndex, afterIndex := nullIndex(r.data[r.index:], encoding)
+	if atIndex == -1 {
+		return "", errors.New("ReadNullTermString: tag malformed. Expecting null terminator in string, but none found.")
+	}
+
 	b, err := r.ReadNumBytes(afterIndex)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Right now the way we id3-go reads UnsynchTextFrames is with
ParseUnsynchTextFrame (v2/reader.go:411). After reading the first byte
of the tag contents for the encoding and the next three for the language
it then tries to read a null terminated string to get the "Short Content
Description" (from the id3v2.3 spec section 4.11). If the tag is
malformed, though, and does not contain a null terminator then nullIndex
(encodedbytes/util.go:121) returns -1 for the index of the null
terminator and the index right after.

Since ReadNullTermString (encodedbytes/reader.go:74) never checks this
value it ends up using the value returned (-1) to index a slice it read
from the reader, resulting in a panic.

This fix simply checks if the atIndex value is -1 and if it is returns
with an empty string and an error indicating a malformed tag.

I ran into this with an mp3 where it looks like the the id3 editor had some weird issues with Unicode and seemed to try to encode the short description part of the tag as FE FF 00 (to indicate that it is blank) followed by the full text.