### PR TITLE
deal with unsynchronization (read)

### DIFF
--- a/v2/id3v2.go
+++ b/v2/id3v2.go
@@ -21,7 +21,7 @@ type Tag struct {
 	padding               uint
 	commonMap             map[string]FrameType
 	frameHeaderSize       int
-	frameConstructor      func(io.Reader) Framer
+	frameConstructor      func(io.Reader, bool) Framer
 	frameBytesConstructor func(Framer) []byte
 	dirty                 bool
 }
@@ -71,7 +71,7 @@ func ParseTag(readSeeker io.ReadSeeker) *Tag {
 	var frame Framer
 	size := int(t.size)
 	for size > 0 {
-		frame = t.frameConstructor(readSeeker)
+		frame = t.frameConstructor(readSeeker, header.unsynchronization)
 
 		if frame == nil {
 			break

--- a/v2/id3v22_test.go
+++ b/v2/id3v22_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestV22Frame(t *testing.T) {
 	textData := []byte{84, 84, 50, 0, 0, 13, 0, 77, 105, 99, 104, 97, 101, 108, 32, 89, 97, 110, 103}
-	frame := ParseV22Frame(bytes.NewReader(textData))
+	frame := ParseV22Frame(bytes.NewReader(textData),false)
 	textFrame, ok := frame.(*TextFrame)
 	if !ok {
 		t.Errorf("ParseV23Frame on text data returns wrong type")

--- a/v2/id3v23_test.go
+++ b/v2/id3v23_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestV23Frame(t *testing.T) {
 	textData := []byte{84, 80, 69, 49, 0, 0, 0, 13, 0, 0, 0, 77, 105, 99, 104, 97, 101, 108, 32, 89, 97, 110, 103}
-	frame := ParseV23Frame(bytes.NewReader(textData))
+	frame := ParseV23Frame(bytes.NewReader(textData),false)
 	textFrame, ok := frame.(*TextFrame)
 	if !ok {
 		t.Errorf("ParseV23Frame on text data returns wrong type")


### PR DESCRIPTION
I came accross some files which had the unsynchronization bit set to 1, and the library didn't take it into account, thus reading completly false data
This patch is for reading such file only. I don't have yet to write tags, but the simplest way to do it is to put the unsynchronization bit to 0 and rewrite all tags.
This patch may need some factorisation, but I'm not sure where to put the unsynchronizationRead function
