### PR TITLE
Add support for iTunes TCMP Frame

### DIFF
--- a/v2/id3v23.go
+++ b/v2/id3v23.go
@@ -104,6 +104,7 @@ var (
 		"TXXX": FrameType{id: "TXXX", description: "User defined text information frame", constructor: ParseDescTextFrame},
 		"UFID": FrameType{id: "UFID", description: "Unique file identifier", constructor: ParseIdFrame},
 		"USER": FrameType{id: "USER", description: "Terms of use", constructor: ParseDataFrame},
+		"TCMP": FrameType{id: "TCMP", description: "Part of a compilation (iTunes extension)", constructor: ParseTextFrame},
 		"USLT": FrameType{id: "USLT", description: "Unsychronized lyric/text transcription", constructor: ParseUnsynchTextFrame},
 		"WCOM": FrameType{id: "WCOM", description: "Commercial information", constructor: ParseDataFrame},
 		"WCOP": FrameType{id: "WCOP", description: "Copyright/Legal information", constructor: ParseDataFrame},


### PR DESCRIPTION
Add support for iTunes TCMP frame. It's use by MusicBrainz piccard too