### PR TITLE
UsefullBytes (ex ImageFrame)

### DIFF
--- a/v2/frame.go
+++ b/v2/frame.go
@@ -30,7 +30,7 @@ type Framer interface {
 	FormatFlags() byte
 	String() string
 	Bytes() []byte
-	UsefullBytes() []byte
+	Data() []byte
 	setOwner(*Tag)
 }
 
@@ -114,10 +114,6 @@ func (f DataFrame) Bytes() []byte {
 	return f.data
 }
 
-func (f DataFrame) UsefullBytes() []byte {
-	return f.data
-}
-
 // IdFrame represents identification tags
 type IdFrame struct {
 	FrameHead
@@ -198,7 +194,7 @@ func (f IdFrame) Bytes() []byte {
 	return bytes
 }
 
-func (f IdFrame) UsefullBytes() []byte {
+func (f IdFrame) Data() []byte {
 	var err error
 	bytes := make([]byte, f.Size())
 	wr := encodedbytes.NewWriter(bytes)
@@ -309,7 +305,7 @@ func (f TextFrame) Bytes() []byte {
 	return bytes
 }
 
-func (f TextFrame) UsefullBytes() []byte {
+func (f TextFrame) Data() []byte {
 	var err error
 	bytes := make([]byte, f.Size())
 	wr := encodedbytes.NewWriter(bytes)
@@ -423,7 +419,7 @@ func (f DescTextFrame) Bytes() []byte {
 	return bytes
 }
 
-func (f DescTextFrame) UsefullBytes() []byte {
+func (f DescTextFrame) Data() []byte {
 	var err error
 	bytes := make([]byte, f.Size())
 	wr := encodedbytes.NewWriter(bytes)
@@ -518,7 +514,7 @@ func (f UnsynchTextFrame) Bytes() []byte {
 	return bytes
 }
 
-func (f UnsynchTextFrame) UsefullBytes() []byte {
+func (f UnsynchTextFrame) Data() []byte {
 	var err error
 	bytes := make([]byte, f.Size())
 	wr := encodedbytes.NewWriter(bytes)
@@ -637,7 +633,7 @@ func (f ImageFrame) Bytes() []byte {
 	return bytes
 }
 
-func (f ImageFrame) UseFullBytes() []byte {
+func (f ImageFrame) Data() []byte {
 	bytes := make([]byte, len(f.data))
 	wr := encodedbytes.NewWriter(bytes)
 

--- a/v2/frame.go
+++ b/v2/frame.go
@@ -557,7 +557,7 @@ func (f ImageFrame) String() string {
 }
 
 func (f ImageFrame) Bytes() []byte {
-	bytes := make([]byte,len(f.data) )
+	bytes := make([]byte, len(f.data))
 	wr := encodedbytes.NewWriter(bytes)
 
 	if n, err := wr.Write(f.data); n < len(f.data) || err != nil {

--- a/v2/frame.go
+++ b/v2/frame.go
@@ -30,6 +30,7 @@ type Framer interface {
 	FormatFlags() byte
 	String() string
 	Bytes() []byte
+	UsefullBytes() []byte
 	setOwner(*Tag)
 }
 
@@ -113,6 +114,10 @@ func (f DataFrame) Bytes() []byte {
 	return f.data
 }
 
+func (f DataFrame) UsefullBytes() []byte {
+	return f.data
+}
+
 // IdFrame represents identification tags
 type IdFrame struct {
 	FrameHead
@@ -185,6 +190,18 @@ func (f IdFrame) Bytes() []byte {
 	if err = wr.WriteString(f.ownerIdentifier, encodedbytes.NativeEncoding); err != nil {
 		return bytes
 	}
+
+	if _, err = wr.Write(f.identifier); err != nil {
+		return bytes
+	}
+
+	return bytes
+}
+
+func (f IdFrame) UsefullBytes() []byte {
+	var err error
+	bytes := make([]byte, f.Size())
+	wr := encodedbytes.NewWriter(bytes)
 
 	if _, err = wr.Write(f.identifier); err != nil {
 		return bytes
@@ -284,6 +301,18 @@ func (f TextFrame) Bytes() []byte {
 	if err = wr.WriteByte(f.encoding); err != nil {
 		return bytes
 	}
+
+	if err = wr.WriteString(f.text, f.encoding); err != nil {
+		return bytes
+	}
+
+	return bytes
+}
+
+func (f TextFrame) UsefullBytes() []byte {
+	var err error
+	bytes := make([]byte, f.Size())
+	wr := encodedbytes.NewWriter(bytes)
 
 	if err = wr.WriteString(f.text, f.encoding); err != nil {
 		return bytes
@@ -394,6 +423,18 @@ func (f DescTextFrame) Bytes() []byte {
 	return bytes
 }
 
+func (f DescTextFrame) UsefullBytes() []byte {
+	var err error
+	bytes := make([]byte, f.Size())
+	wr := encodedbytes.NewWriter(bytes)
+
+	if err = wr.WriteString(f.text, f.encoding); err != nil {
+		return bytes
+	}
+
+	return bytes
+}
+
 // UnsynchTextFrame represents frames that contain unsynchronized text
 type UnsynchTextFrame struct {
 	DescTextFrame
@@ -469,6 +510,18 @@ func (f UnsynchTextFrame) Bytes() []byte {
 	if err = wr.WriteNullTermString(f.description, f.encoding); err != nil {
 		return bytes
 	}
+
+	if err = wr.WriteString(f.text, f.encoding); err != nil {
+		return bytes
+	}
+
+	return bytes
+}
+
+func (f UnsynchTextFrame) UsefullBytes() []byte {
+	var err error
+	bytes := make([]byte, f.Size())
+	wr := encodedbytes.NewWriter(bytes)
 
 	if err = wr.WriteString(f.text, f.encoding); err != nil {
 		return bytes
@@ -557,6 +610,34 @@ func (f ImageFrame) String() string {
 }
 
 func (f ImageFrame) Bytes() []byte {
+	var err error
+	bytes := make([]byte, f.Size())
+	wr := encodedbytes.NewWriter(bytes)
+
+	if err = wr.WriteByte(f.encoding); err != nil {
+		return bytes
+	}
+
+	if err = wr.WriteString(f.mimeType, encodedbytes.NativeEncoding); err != nil {
+		return bytes
+	}
+
+	if err = wr.WriteByte(f.pictureType); err != nil {
+		return bytes
+	}
+
+	if err = wr.WriteString(f.description, f.encoding); err != nil {
+		return bytes
+	}
+
+	if n, err := wr.Write(f.data); n < len(f.data) || err != nil {
+		return bytes
+	}
+
+	return bytes
+}
+
+func (f ImageFrame) UseFullBytes() []byte {
 	bytes := make([]byte, len(f.data))
 	wr := encodedbytes.NewWriter(bytes)
 

--- a/v2/frame.go
+++ b/v2/frame.go
@@ -557,25 +557,8 @@ func (f ImageFrame) String() string {
 }
 
 func (f ImageFrame) Bytes() []byte {
-	var err error
-	bytes := make([]byte, f.Size())
+	bytes := make([]byte,len(f.data) )
 	wr := encodedbytes.NewWriter(bytes)
-
-	if err = wr.WriteByte(f.encoding); err != nil {
-		return bytes
-	}
-
-	if err = wr.WriteString(f.mimeType, encodedbytes.NativeEncoding); err != nil {
-		return bytes
-	}
-
-	if err = wr.WriteByte(f.pictureType); err != nil {
-		return bytes
-	}
-
-	if err = wr.WriteString(f.description, f.encoding); err != nil {
-		return bytes
-	}
 
 	if n, err := wr.Write(f.data); n < len(f.data) || err != nil {
 		return bytes


### PR DESCRIPTION
It's somewhat ankward to have to reparse the result of the Bytes() method to have the real image file.
The informations about description and picture type are already in the String() method.
I just removed the useless part and let only the binary image in the result.

This way, I can simply do a ioutil.WriteFile("image.jpg", tag.Bytes(), 0644) to have my image
