### PR TITLE
iconv issue on some platforms

### DIFF
--- a/encodedbytes/util.go
+++ b/encodedbytes/util.go
@@ -32,12 +32,16 @@ var (
 	Encoders = make([]*iconv.Converter, len(EncodingMap))
 )
 
-func init() {
+func Init() {
 	n := EncodingForIndex(NativeEncoding)
 	for i, e := range EncodingMap {
 		Decoders[i], _ = iconv.NewConverter(e.Name, n)
 		Encoders[i], _ = iconv.NewConverter(n, e.Name)
 	}
+}
+
+func init() {
+	Init()
 }
 
 // Form an integer from concatenated bits

--- a/v2/id3v2.go
+++ b/v2/id3v2.go
@@ -29,6 +29,7 @@ type Tag struct {
 // Creates a new tag
 func NewTag(version byte) *Tag {
 	header := &Header{version: version}
+	encodedbytes.Init()
 
 	t := &Tag{
 		Header: header,


### PR DESCRIPTION
I have a strange issue on my linyx server, that I don't have on my mac.
After reading some files, the library start to output japanese caracters and other garbage output.
I found I could work around the issue by reinitializing the iconv structure in encodedbytes by relaunching the init() method.