### PR TITLE
Fixes UFID tag writing

### DIFF
--- a/v2/frame.go
+++ b/v2/frame.go
@@ -186,6 +186,10 @@ func (f IdFrame) Bytes() []byte {
 		return bytes
 	}
 
+	if err = wr.WriteByte(0); err != nil {
+		return bytes
+	}
+
 	if _, err = wr.Write(f.identifier); err != nil {
 		return bytes
 	}


### PR DESCRIPTION
The null byte between the owner identifier and the identifier was
missing. More details available at:

https://id3.org/id3v2.4.0-frames section 4.1